### PR TITLE
Fixes #19

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,6 +70,7 @@ parts:
       - libgl1-mesa-dev
     stage-packages:
       - libtinfo6
+      - libncursesw6
       - libfontconfig1
       - libfreetype6
       - libpng16-16


### PR DESCRIPTION
There is an incompatibility between libtinfo6 and libncursesw6 libraries on Ubuntu 21.04 which causes apps like nano to fail. So I'm embedding libncursesw6 into the snap.