### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ distributions.</p>
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 
+The snap requires glibc version 2.33 or higher to be installed. For Ubuntu, this means Ubuntu 22.04 LTS or newer.
+
 | [![Alper Kanat](https://gravatar.com/avatar/ef468cdb9947165b09d2afae24d6491c/?s=128)](https://github.com/tunix/) |
 | :---: |
 | [Alper Kanat](https://github.com/tunix/) |


### PR DESCRIPTION
Trying to run alacritty on 20.04 LTS gives an error message:

/bin/bash: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/alacritty/85/lib/x86_64-linux-gnu/libtinfo.so.6)