### PR TITLE
Update alacritty to v0.13.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,7 +55,7 @@ parts:
   alacritty:
     plugin: rust
     source: https://github.com/alacritty/alacritty.git
-    source-tag: v0.12.3
+    source-tag: v0.13.0
     parse-info:
       - extra/linux/org.alacritty.Alacritty.appdata.xml
     rust-path:


### PR DESCRIPTION
Updates the snap package to the latest version of Alacritty: 0.13.0 released 2023-12-27.

https://github.com/alacritty/alacritty/releases/tag/v0.13.0