### PR TITLE
Update Alacritty to v0.13.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,7 +55,7 @@ parts:
   alacritty:
     plugin: rust
     source: https://github.com/alacritty/alacritty.git
-    source-tag: v0.13.0
+    source-tag: v0.13.1
     parse-info:
       - extra/linux/org.alacritty.Alacritty.appdata.xml
     rust-path:


### PR DESCRIPTION
Update the Alacritty snap to latest release, v0.13.1.
https://github.com/alacritty/alacritty/releases/tag/v0.13.1