### PR TITLE
fix: don't set LD_LIBRARY_PATH in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,6 +82,8 @@ parts:
       - extra/linux/org.alacritty.Alacritty.appdata.xml
     rust-path:
       - alacritty
+    build-attributes:
+      - enable-patchelf
     build-packages:
       - cmake
       - pkg-config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,6 @@ apps:
     desktop: usr/share/applications/Alacritty.desktop
     environment:
       LC_ALL: C.UTF-8
-      LD_LIBRARY_PATH: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET"
 
 layout:
   /usr/lib/x86_64-linux-gnu/dri:


### PR DESCRIPTION
This snap currently sets `LD_LIBRARY_PATH`, which is incorrect for a classic snap. This PR stops that behaviour and uses patchelf instead. Tested locally and seems to function correctly.