### PR TITLE
fix: include libwayland-egl1 in stage-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,6 +127,7 @@ parts:
       - libffi7
       - libxkbcommon0
       - libnss-sss
+      - libwayland-egl1
     override-build: |
       craftctl default
 


### PR DESCRIPTION
For a descrition of what this PR fixes, please read #23, but this should fix it by including the library.