### PR TITLE
Fix mouse cursor theme issue

### DIFF
--- a/snap/local/custom-wrapper
+++ b/snap/local/custom-wrapper
@@ -3,6 +3,4 @@
 export XDG_CONFIG_HOME="$SNAP_REAL_HOME/.config"
 export XDG_DATA_HOME="$SNAP_REAL_HOME/.local/share"
 
-unset XCURSOR_PATH
-
 exec "$@"


### PR DESCRIPTION
This should address #21.

Unless I'm missing something, this environment variable (`XCURSOR_PATH`) is set by the `desktop-launch` wrapper that comes from the `snapcraft-desktop-helpers` set of utilities in order to match the base theme on the workstation; unsetting this variable here undoes that work, and it leads to Alacritty using a white mouse cursor instead of falling back to the default cursor that would be expected (Yaru in most cases).

I think that if someone wanted to modify this behavior (I noticed that this line was originally added to "respect user customization"), they should address it upstream in
[snapcraft-desktop-helpers](https://github.com/ubuntu/snapcraft-desktop-helpers), where `XCURSOR_PATH` is being modified without appending/preppending, but not in Alacritty.

I've tested these changes locally and they seems to fix the cursor issue. Let me know what you think, or if I missed something in this!