### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: alacritty
-version: 0.14.0
+version: 0.15.0
 summary: A cross-platform, GPU enhanced terminal emulator.
 description: |
   Alacritty is a modern terminal emulator that comes with sensible defaults, but allows for


### PR DESCRIPTION
A new version is out: https://github.com/alacritty/alacritty/releases/tag/v0.15.0.
