### PR TITLE
bump new version 0.17.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: alacritty
-version: 0.16.1
+version: 0.17.0
 summary: A cross-platform, GPU enhanced terminal emulator.
 description: |
   Alacritty is a modern terminal emulator that comes with sensible defaults, but allows for


### PR DESCRIPTION
Alacritty 0.17.0 is here

[release](https://github.com/alacritty/alacritty/releases/tag/v0.17.0)