### PR TITLE
fix: wrong cursor loaded for x11 apps opened from alacritty

### DIFF
--- a/snap/local/custom-wrapper
+++ b/snap/local/custom-wrapper
@@ -2,5 +2,7 @@
 
 export XDG_CONFIG_HOME="$SNAP_REAL_HOME/.config"
 export XDG_DATA_HOME="$SNAP_REAL_HOME/.local/share"
+# Fix for the wrong cursor loaded opening X11 apps from alacritty terminal
+export XCURSOR_PATH="/usr/share/icons"
 
 exec "$@"


### PR DESCRIPTION
This fix annoying issue when launching vscode from alacritty the mouse cursor would look bad and different from regular vscode mouse cursor.

It can also be fixed locally using this configuration file:
```toml
[env]
# Fix for the wrong cursor loaded opening X11 apps from alacritty terminal
XCURSOR_PATH = "/usr/share/icons"
```
