### PR TITLE
docs: update workflow badge links [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
 <a href="https://snapcraft.io/alacritty"><img src="https://snapcraft.io/alacritty/badge.svg" alt="Snap Status"></a>
-<a href="https://github.com/snapcrafters/alacritty/actions/workflows/sync-upstream.yml"><img src="https://github.com/snapcrafters/alacritty/actions/workflows/sync-upstream.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/alacritty/actions/workflows/sync-version-with-upstream.yml"><img src="https://github.com/snapcrafters/alacritty/actions/workflows/sync-version-with-upstream.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/alacritty/actions/workflows/release-to-candidate.yml"><img src="https://github.com/snapcrafters/alacritty/actions/workflows/release-to-candidate.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/alacritty/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/alacritty/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </p>


### PR DESCRIPTION
## Summary
- Updates README workflow badge links to point at the canonical renamed workflow files.
- Keeps badge href and image URLs aligned with the standard `.yml` workflow filenames.

## Files
- `README.md`

## Replacements
- `sync-upstream.yml -> sync-version-with-upstream.yml`

## Verification
- `git diff --check`
- Commit message includes `[skip ci]`.

@jnsgruk please review.
